### PR TITLE
Manifest has a wrong propertyname

### DIFF
--- a/examples/csharp/extension-virtual-channel-csharp/manifest/dcv_extension_manifest.json
+++ b/examples/csharp/extension-virtual-channel-csharp/manifest/dcv_extension_manifest.json
@@ -4,5 +4,5 @@
     "path": "path/to/dcvextension.exe",
     "start_on_server": true,
     "start_on_client": true,
-    "data_channel_namespace": "dcvtest"
+    "virtual_channel_namespace": "dcvtest"
 }


### PR DESCRIPTION
In the Manifest was a wrong propertyname.
After fixing that the virtual channel is able to connect.
